### PR TITLE
Update repository references for rename to ably-pubsub-java

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -14,6 +14,6 @@ jobs:
       deployments: write
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
-      repository-name: ably-java
+      repository-name: ably-pubsub-java
     secrets:
       ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -21,7 +21,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-java
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-pubsub-java
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - name: Set up the JDK

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   run-on-release:
     runs-on: ubuntu-latest
-    if: github.repository == 'ably/ably-java'
+    if: github.repository == 'ably/ably-pubsub-java'
     permissions:
       contents: read
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ For more details see the [`gradle-lint`](gradle-lint) project.
 We regression-test the library against a selection of Java and Android platforms (which will change over time, but usually consists of the versions that are supported upstream). Please refer to [.travis.yml](./.travis.yml) for the set of versions that currently undergo CI testing..
 
 We'll happily support (and investigate reported problems with) any reasonably-widely-used platform, Java or Android.
-If you find any compatibility issues, please [do raise an issue](https://github.com/ably/ably-java/issues/new) in this repository or [contact Ably customer support](https://support.ably.io/) for advice.
+If you find any compatibility issues, please [do raise an issue](https://github.com/ably/ably-pubsub-java/issues/new) in this repository or [contact Ably customer support](https://support.ably.io/) for advice.
 
 ### IDE Support
 
@@ -126,7 +126,7 @@ The gradle project files can be imported to create projects in IntelliJ IDEA, Ec
 The top-level ably-java project can be imported into IntelliJ IDEA, enabling development of both the java and android projects. This has been tested with IntelliJ IDEA Ultimate 2017.2. To import into IDEA:
 
 - do File->New->Project from Existing Sources...
-- select ably-java/settings.gradle
+- select ably-pubsub-java/settings.gradle
 - in the import dialog, check "Use auto-import" and uncheck "Create separate module per source set"
 - select "ok"
 
@@ -166,7 +166,7 @@ This has been tested with Android Studio 3.0.1.
 
 To import into Android Studio:
 - do Import project (Gradle, Eclipse ADT, etc);
-- select ably-java/android/build.gradle;
+- select ably-pubsub-java/android/build.gradle;
 - select OK to Gradle Sync.
 
 This creates a single android project and module.
@@ -255,7 +255,7 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 5. Make a PR against `main`
 6. Once the PR is approved, merge it into `main`
 7. Create the release and the release tag on Github including populating the release notes
-8. Use the [GitHub action](https://github.com/ably/ably-java/actions/workflows/release.yaml) to publish the release. Run the workflow on the latest release tag.
+8. Use the [GitHub action](https://github.com/ably/ably-pubsub-java/actions/workflows/release.yaml) to publish the release. Run the workflow on the latest release tag.
 9. Create the entry on the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/))
 
 ### Signing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Ably Pub/Sub Java Header](images/javaSDK-github.png)
 [![Latest Version](https://img.shields.io/maven-central/v/io.ably/ably-java)](https://central.sonatype.com/artifact/io.ably/ably-java)
-[![License](https://badgen.net/github/license/ably/ably-java)](https://github.com/ably/ably-java/blob/main/LICENSE)
+[![License](https://badgen.net/github/license/ably/ably-pubsub-java)](https://github.com/ably/ably-pubsub-java/blob/main/LICENSE)
 
 # Ably Pub/Sub Java SDK
 
@@ -193,4 +193,4 @@ The [CHANGELOG.md](./CHANGELOG.md) contains details of the latest releases for t
 
 ## Support, feedback, and troubleshooting
 
-For help or technical support, visit Ably's [support page](https://ably.com/support) or [GitHub Issues](https://github.com/ably/ably-java/issues) for community-reported bugs and discussions.
+For help or technical support, visit Ably's [support page](https://ably.com/support) or [GitHub Issues](https://github.com/ably/ably-pubsub-java/issues) for community-reported bugs and discussions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 GROUP=io.ably
 VERSION_NAME=1.8.0
 POM_INCEPTION_YEAR=2015
-POM_URL=https://github.com/ably/ably-java
-POM_SCM_URL=https://github.com/ably/ably-java/
-POM_SCM_CONNECTION=scm:git:git://github.com/ably/ably-java.git
-POM_SCM_DEV_CONNECTION=scm:git:git@github.com:ably/ably-java.git
+POM_URL=https://github.com/ably/ably-pubsub-java
+POM_SCM_URL=https://github.com/ably/ably-pubsub-java/
+POM_SCM_CONNECTION=scm:git:git://github.com/ably/ably-pubsub-java.git
+POM_SCM_DEV_CONNECTION=scm:git:git@github.com:ably/ably-pubsub-java.git
 
 POM_LICENSE_NAME=The Apache Software License, Version 2.0
-POM_LICENSE_URL=https://raw.github.com/ably/ably-java/main/LICENSE
+POM_LICENSE_URL=https://raw.github.com/ably/ably-pubsub-java/main/LICENSE
 POM_LICENSE_DIST=repo
 
 POM_DEVELOPER_ID=ably

--- a/overview.html
+++ b/overview.html
@@ -1,7 +1,7 @@
 <HTML>
 <BODY>
 <h1 id="ably-java-client-library-sdk-api-reference">Ably Java Client Library SDK API Reference</h1>
-<p>The Java Client Library SDK supports a realtime and a REST interface. The Java API references are generated from the <a href="https://github.com/ably/ably-java/">Ably Java Client Library SDK source code</a> using <a href="https://en.wikipedia.org/wiki/Javadoc">JavaDoc</a> and structured by classes.</p>
+<p>The Java Client Library SDK supports a realtime and a REST interface. The Java API references are generated from the <a href="https://github.com/ably/ably-pubsub-java/">Ably Java Client Library SDK source code</a> using <a href="https://en.wikipedia.org/wiki/Javadoc">JavaDoc</a> and structured by classes.</p>
 <p>The realtime interface enables a client to maintain a persistent connection to Ably and publish, subscribe and be present on channels. The REST interface is stateless and typically implemented server-side. It is used to make requests such as retrieving statistics, token authentication and publishing to a channel.</p>
 <p>View the <a href="https://ably.com/docs/">Ably docs</a> for conceptual information on using Ably, and for API references featuring all languages. The combined <a href="https://ably.com/docs/api/">API references</a> are organized by features and split between the <a href="https://ably.com/docs/api/realtime-sdk">realtime</a> and <a href="https://ably.com/docs/api/rest-sdk">REST</a> interfaces.</p>
 </BODY>


### PR DESCRIPTION
**Do not merge until the repository is renamed `ably-java` → `ably-pubsub-java`, in the programme's rename freeze window.** Merging early points `javadoc.yml` and `features.yml` at the `ably-sdk-builds-ably-pubsub-java` IAM role, whose OIDC trust is bound to the new repository name, so the credential step would fail; and the `release.yaml` repository guard would skip every run. Conversely, once the rename happens the old role name stops matching and the old guard skips, so this is a same-window change in both directions.

Sibling of [ably-pubsub-ruby#457](https://github.com/ably/ably-pubsub-ruby/pull/457), [ably-dotnet#1332](https://github.com/ably/ably-dotnet/pull/1332), [ably-python#682](https://github.com/ably/ably-python/pull/682) and [ably-js#2298](https://github.com/ably/ably-js/pull/2298). It only updates strings inside the repo; it does not rename anything.

## What changed

- **`.github/workflows/javadoc.yml`** — `role-to-assume` → `ably-sdk-builds-ably-pubsub-java`. The role is provisioned by [infrastructure#13005](https://github.com/ably/infrastructure/pull/13005) (merged 2026-09-01); [infrastructure#13054](https://github.com/ably/infrastructure/pull/13054) adds the ID-qualified OIDC subject GitHub uses for repos renamed after 2026-07-15.
- **`.github/workflows/features.yml`** — `repository-name: ably-pubsub-java`.
- **`.github/workflows/release.yaml`** — `if: github.repository == 'ably/ably-pubsub-java'`. ⚠️ This guard silently skips the Maven Central release job on a mismatch, so it *must* flip in the same window as the rename.
- **`gradle.properties`** — `POM_URL`, `POM_SCM_URL`, `POM_SCM_CONNECTION`, `POM_SCM_DEV_CONNECTION`, `POM_LICENSE_URL`. These are published into the POM on Maven Central, so the next release advertises the new repo. `GROUP`/artifact coordinates untouched.
- **`README.md`** — licence badge and GitHub Issues link.
- **`CONTRIBUTING.md`** — issue link, the two IDE "select `ably-java/…`" checkout-path steps, and the release-workflow link.
- **`overview.html`** — source-code link on the Javadoc front page.

## Deliberately left as-is

- **`ably-java/<version>` agent identifier** and the `pubsub-adapter` tests asserting on it — a registered identifier, not a repository reference. The family rename to `ably-pubsub-java` lands on the split branch (#1233), gated on [ably-common#361](https://github.com/ably/ably-common/pull/361).
- **Maven coordinates** `io.ably:ably-java` — README badges/links, `deploy/check-archives.sh` path. Artifact IDs, not the repo.
- **`CHANGELOG.md`**, issue/PR links in code comments and tests, `.claude/skills` prose, and the `ably-java-secring.gpg` example filename — history / local names; GitHub's redirect covers the links.
- **Maven Central publishing** authenticates with Sonatype credentials in repo secrets, not OIDC, so nothing to rebind registry-side. Secrets carry over with the rename.

## Post-rename verification

- [ ] `git ls-remote` from an existing checkout and web redirects for repo / a PR / a file permalink.
- [ ] `check.yml` matrix green.
- [ ] `javadoc.yml` and `features.yml` runs: AWS credential step succeeds **and the upload lands** at `sdk.ably.com/builds/ably/ably-pubsub-java/main/…` (the upload failure mode is silent).
- [ ] `release.yaml` dispatched on the latest release tag reaches the "Compare version with tag" step (proves the repository guard) — cancel before publish, or wait for the next real release.
- [ ] Merge `main` into `integration/v2` and the `integration/split-*` chain, which carry their own copies of the workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
